### PR TITLE
Classic compatibility layer

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -66,6 +66,8 @@ local L, C, S = PhanxChat.L, PhanxChat.ChannelNames, PhanxChat.ShortStrings
 PhanxChat.name = PHANXCHAT
 PhanxChat.debug = false
 
+PhanxChat.compatRelease = WOW_PROJECT_ID == WOW_PROJECT_MAINLINE
+
 PhanxChat.RunOnLoad = {}
 PhanxChat.RunOnProcessFrame = {}
 

--- a/Modules/HideButtons.lua
+++ b/Modules/HideButtons.lua
@@ -48,8 +48,10 @@ function PhanxChat:SetHideButtons(v)
 		ChatFrameMenuButton:SetScript("OnShow", ChatFrameMenuButton.Hide)
 		ChatFrameMenuButton:Hide()
 
-		QuickJoinToastButton:SetScript("OnShow", QuickJoinToastButton.Hide)
-		QuickJoinToastButton:Hide()
+		if PhanxChat.compatRelease then
+			QuickJoinToastButton:SetScript("OnShow", QuickJoinToastButton.Hide)
+			QuickJoinToastButton:Hide()
+		end
 	elseif not self.isLoading then
 		ChatFrameChannelButton:SetScript("OnShow", nil)
 		ChatFrameChannelButton:Show()
@@ -57,8 +59,10 @@ function PhanxChat:SetHideButtons(v)
 		ChatFrameMenuButton:SetScript("OnShow", nil)
 		ChatFrameMenuButton:Show()
 
-		QuickJoinToastButton:SetScript("OnShow", nil)
-		QuickJoinToastButton:Show()
+		if PhanxChat.compatRelease then
+			QuickJoinToastButton:SetScript("OnShow", nil)
+			QuickJoinToastButton:Show()
+		end
 	end
 end
 

--- a/Modules/HideTextures.lua
+++ b/Modules/HideTextures.lua
@@ -107,9 +107,11 @@ function PhanxChat:HideTextures(frame)
 			editBox.right:SetAlpha(0)
 			editBox.mid:SetAlpha(0)
 
-			editBox.focusLeft:SetTexture([[Interface\ChatFrame\UI-ChatInputBorder-Left2]])
-			editBox.focusRight:SetTexture([[Interface\ChatFrame\UI-ChatInputBorder-Right2]])
-			editBox.focusMid:SetTexture([[Interface\ChatFrame\UI-ChatInputBorder-Mid2]])
+			if PhanxChat.compatRelease then
+				editBox.focusLeft:SetTexture([[Interface\ChatFrame\UI-ChatInputBorder-Left2]])
+				editBox.focusRight:SetTexture([[Interface\ChatFrame\UI-ChatInputBorder-Right2]])
+				editBox.focusMid:SetTexture([[Interface\ChatFrame\UI-ChatInputBorder-Mid2]])
+			end
 		end
 
 		local tab = frame.tab


### PR DESCRIPTION
### What does this implement/fix? Explain your changes ###

This adds a basic classic compatibility layer

### Does this close any currently open issues? ###

#33 

### Any relevant logs, error output, etc? ###

None

### Any other comments? ###

On first load of the AddOn the call of  `PhanxChat:ProcessFrame` -> `frame:AddMessage(history[i])` adds messages other AddOns might have written to chat on load before, which seems not to happen on live